### PR TITLE
MAST-3372 Investigate TIF Conversion Failure in Frame Byte Range Pull from IMFA MXF on S3

### DIFF
--- a/libavcodec/tiff.h
+++ b/libavcodec/tiff.h
@@ -57,6 +57,7 @@ enum TiffTags {
     TIFF_MAKE               = 0x10F,
     TIFF_MODEL              = 0x110,
     TIFF_STRIP_OFFS         = 0x111,
+    TIFF_ORIENTATION        = 0x112,
     TIFF_SAMPLES_PER_PIXEL  = 0x115,
     TIFF_ROWSPERSTRIP       = 0x116,
     TIFF_STRIP_SIZE,


### PR DESCRIPTION
* avcodec/tiff: Improve error detection when decoding tags for orientation, stripOffset, stripSizes, resolutionUnit